### PR TITLE
feat: structured agent-friendly API error responses

### DIFF
--- a/apps/web/src/app/api/webhooks/[id]/route.ts
+++ b/apps/web/src/app/api/webhooks/[id]/route.ts
@@ -23,10 +23,7 @@ export async function DELETE(
       .returning({ id: webhookConfigs.id });
 
     if (deleted.length === 0) {
-      return createErrorResponse(
-        "WEBHOOK_NOT_FOUND",
-        "Webhook not found."
-      );
+      return createErrorResponse("WEBHOOK_NOT_FOUND", "Webhook not found.");
     }
 
     return new NextResponse(null, { status: 204 });

--- a/apps/web/src/app/api/webhooks/[id]/route.ts
+++ b/apps/web/src/app/api/webhooks/[id]/route.ts
@@ -1,6 +1,7 @@
 import { db, webhookConfigs } from "@turbobun/db";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
+import { createErrorResponse } from "../errors";
 
 export async function DELETE(
   _request: Request,
@@ -9,23 +10,31 @@ export async function DELETE(
   const { id } = await params;
 
   if (!id) {
-    return NextResponse.json(
-      { error: "Webhook ID is required." },
-      { status: 400 }
+    return createErrorResponse(
+      "WEBHOOK_ID_REQUIRED",
+      "Webhook ID is required."
     );
   }
 
-  const deleted = await db
-    .delete(webhookConfigs)
-    .where(eq(webhookConfigs.id, id))
-    .returning({ id: webhookConfigs.id });
+  try {
+    const deleted = await db
+      .delete(webhookConfigs)
+      .where(eq(webhookConfigs.id, id))
+      .returning({ id: webhookConfigs.id });
 
-  if (deleted.length === 0) {
-    return NextResponse.json(
-      { error: "Webhook not found." },
-      { status: 404 }
+    if (deleted.length === 0) {
+      return createErrorResponse(
+        "WEBHOOK_NOT_FOUND",
+        "Webhook not found."
+      );
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error("Failed to delete webhook config:", error);
+    return createErrorResponse(
+      "DATABASE_ERROR",
+      "Failed to delete webhook config."
     );
   }
-
-  return new NextResponse(null, { status: 204 });
 }

--- a/apps/web/src/app/api/webhooks/errors.ts
+++ b/apps/web/src/app/api/webhooks/errors.ts
@@ -1,0 +1,144 @@
+import { randomBytes } from "node:crypto";
+import { NextResponse } from "next/server";
+
+const REQUEST_ID_BYTE_LENGTH = 8;
+
+export type ErrorCategory =
+  | "validation"
+  | "authentication"
+  | "not_found"
+  | "conflict"
+  | "internal"
+  | "upstream";
+
+export interface ErrorResponseBody {
+  error: string;
+  code: string;
+  status: number;
+  category: ErrorCategory;
+  retryable: boolean;
+  retry_after?: number;
+  suggested_action: string;
+  request_id: string;
+  timestamp: string;
+}
+
+interface ErrorCode {
+  status: number;
+  category: ErrorCategory;
+  retryable: boolean;
+  retry_after?: number;
+  suggested_action: string;
+}
+
+export const ERROR_CODES = {
+  INVALID_JSON_BODY: {
+    status: 400,
+    category: "validation",
+    retryable: false,
+    suggested_action: "Check that the request body is valid JSON.",
+  },
+  MISSING_REQUIRED_FIELDS: {
+    status: 400,
+    category: "validation",
+    retryable: false,
+    suggested_action:
+      "Provide serverUrl, apiKey, and webhookUrl as non-empty strings.",
+  },
+  INVALID_URL_FORMAT: {
+    status: 400,
+    category: "validation",
+    retryable: false,
+    suggested_action:
+      "Ensure serverUrl and webhookUrl are valid absolute URLs.",
+  },
+  MISSING_QUERY_PARAMS: {
+    status: 400,
+    category: "validation",
+    retryable: false,
+    suggested_action:
+      "Provide serverUrl and apiKey as query params or apiKey via x-api-key header.",
+  },
+  WEBHOOK_ID_REQUIRED: {
+    status: 400,
+    category: "validation",
+    retryable: false,
+    suggested_action: "Provide a valid webhook UUID in the URL path.",
+  },
+  INVALID_CREDENTIALS: {
+    status: 401,
+    category: "authentication",
+    retryable: false,
+    suggested_action:
+      "Verify that serverUrl is reachable and apiKey is correct.",
+  },
+  CREDENTIAL_VERIFICATION_TIMEOUT: {
+    status: 401,
+    category: "authentication",
+    retryable: true,
+    retry_after: 5,
+    suggested_action:
+      "The iMessage server did not respond in time. Wait 5 seconds and retry.",
+  },
+  WEBHOOK_NOT_FOUND: {
+    status: 404,
+    category: "not_found",
+    retryable: false,
+    suggested_action:
+      "The webhook ID does not exist. Verify the ID or list existing webhooks with GET.",
+  },
+  CONFLICT_RETRY: {
+    status: 409,
+    category: "conflict",
+    retryable: true,
+    retry_after: 1,
+    suggested_action:
+      "A concurrent request created this webhook. Retry — the existing record will be returned.",
+  },
+  DATABASE_ERROR: {
+    status: 500,
+    category: "internal",
+    retryable: true,
+    retry_after: 2,
+    suggested_action:
+      "An unexpected database error occurred. Wait 2 seconds and retry. If persistent after 3 attempts, escalate.",
+  },
+  INTERNAL_SERVER_ERROR: {
+    status: 500,
+    category: "internal",
+    retryable: true,
+    retry_after: 2,
+    suggested_action:
+      "An unexpected error occurred. Wait 2 seconds and retry. If persistent after 3 attempts, escalate.",
+  },
+} as const satisfies Record<string, ErrorCode>;
+
+export type ErrorCodeName = keyof typeof ERROR_CODES;
+
+function generateRequestId(): string {
+  return `req_${randomBytes(REQUEST_ID_BYTE_LENGTH).toString("hex")}`;
+}
+
+export function createErrorResponse(
+  code: ErrorCodeName,
+  error: string
+): NextResponse<ErrorResponseBody> {
+  const def = ERROR_CODES[code];
+
+  const body: ErrorResponseBody = {
+    error,
+    code,
+    status: def.status,
+    category: def.category,
+    retryable: def.retryable,
+    suggested_action: def.suggested_action,
+    request_id: generateRequestId(),
+    timestamp: new Date().toISOString(),
+  };
+
+  if ("retry_after" in def) {
+    body.retry_after = def.retry_after;
+  }
+
+  return NextResponse.json(body, { status: def.status });
+}

--- a/apps/web/src/app/api/webhooks/errors.ts
+++ b/apps/web/src/app/api/webhooks/errors.ts
@@ -12,22 +12,22 @@ export type ErrorCategory =
   | "upstream";
 
 export interface ErrorResponseBody {
-  error: string;
-  code: string;
-  status: number;
   category: ErrorCategory;
-  retryable: boolean;
-  retry_after?: number;
-  suggested_action: string;
+  code: string;
+  error: string;
   request_id: string;
+  retry_after?: number;
+  retryable: boolean;
+  status: number;
+  suggested_action: string;
   timestamp: string;
 }
 
 interface ErrorCode {
-  status: number;
   category: ErrorCategory;
-  retryable: boolean;
   retry_after?: number;
+  retryable: boolean;
+  status: number;
   suggested_action: string;
 }
 

--- a/apps/web/src/app/api/webhooks/route.ts
+++ b/apps/web/src/app/api/webhooks/route.ts
@@ -3,9 +3,12 @@ import { AdvancedIMessageKit } from "@photon-ai/advanced-imessage-kit";
 import { db, webhookConfigs } from "@turbobun/db";
 import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
+import { createErrorResponse } from "./errors";
 
 const SIGNING_SECRET_BYTE_LENGTH = 32 as const;
 const VERIFY_TIMEOUT_MS = 5000;
+
+type VerifyResult = "ok" | "invalid" | "timeout";
 
 function generateSigningSecret(): string {
   return randomBytes(SIGNING_SECRET_BYTE_LENGTH).toString("hex");
@@ -23,8 +26,8 @@ function isDbError(err: unknown): err is Error & { code: string } {
 async function verifyServerCredentials(
   serverUrl: string,
   apiKey: string
-): Promise<boolean> {
-  return new Promise<boolean>((resolve) => {
+): Promise<VerifyResult> {
+  return new Promise<VerifyResult>((resolve) => {
     const sdk = new AdvancedIMessageKit({
       serverUrl,
       apiKey,
@@ -32,21 +35,39 @@ async function verifyServerCredentials(
     });
 
     let finished = false;
-    const cleanup = (result: boolean) => {
+    const cleanup = (result: VerifyResult) => {
       if (finished) return;
       finished = true;
       clearTimeout(timer);
-      try { sdk.close(); } catch { /* already closed */ }
+      try {
+        sdk.close();
+      } catch {
+        /* already closed */
+      }
       resolve(result);
     };
 
-    const timer = setTimeout(() => cleanup(false), VERIFY_TIMEOUT_MS);
+    const timer = setTimeout(() => cleanup("timeout"), VERIFY_TIMEOUT_MS);
 
-    sdk.on("ready", () => cleanup(true));
-    sdk.on("error", () => cleanup(false));
+    sdk.on("ready", () => cleanup("ok"));
+    sdk.on("error", () => cleanup("invalid"));
 
-    sdk.connect().catch(() => cleanup(false));
+    sdk.connect().catch(() => cleanup("invalid"));
   });
+}
+
+function verifyOrError(result: VerifyResult): NextResponse | null {
+  if (result === "ok") return null;
+  if (result === "timeout") {
+    return createErrorResponse(
+      "CREDENTIAL_VERIFICATION_TIMEOUT",
+      "Credential verification timed out."
+    );
+  }
+  return createErrorResponse(
+    "INVALID_CREDENTIALS",
+    "Invalid server URL or API key."
+  );
 }
 
 export async function POST(request: Request): Promise<NextResponse> {
@@ -54,10 +75,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON body." },
-      { status: 400 }
-    );
+    return createErrorResponse("INVALID_JSON_BODY", "Invalid JSON body.");
   }
 
   const { serverUrl, apiKey, webhookUrl } = body as Record<string, unknown>;
@@ -70,9 +88,9 @@ export async function POST(request: Request): Promise<NextResponse> {
     !apiKey ||
     !webhookUrl
   ) {
-    return NextResponse.json(
-      { error: "serverUrl, apiKey, and webhookUrl are required strings." },
-      { status: 400 }
+    return createErrorResponse(
+      "MISSING_REQUIRED_FIELDS",
+      "serverUrl, apiKey, and webhookUrl are required strings."
     );
   }
 
@@ -80,18 +98,15 @@ export async function POST(request: Request): Promise<NextResponse> {
     new URL(serverUrl);
     new URL(webhookUrl);
   } catch {
-    return NextResponse.json(
-      { error: "Invalid URL format." },
-      { status: 400 }
+    return createErrorResponse(
+      "INVALID_URL_FORMAT",
+      "Invalid URL format for serverUrl or webhookUrl."
     );
   }
 
-  if (!(await verifyServerCredentials(serverUrl, apiKey))) {
-    return NextResponse.json(
-      { error: "Invalid server URL or API key." },
-      { status: 401 }
-    );
-  }
+  const verifyResult = await verifyServerCredentials(serverUrl, apiKey);
+  const verifyError = verifyOrError(verifyResult);
+  if (verifyError) return verifyError;
 
   let result: { id: string; signingSecret: string; created: boolean };
 
@@ -122,7 +137,11 @@ export async function POST(request: Request): Promise<NextResponse> {
             .where(eq(webhookConfigs.id, existing.id));
           return { id: existing.id, signingSecret, created: false };
         }
-        return { id: existing.id, signingSecret: existing.signingSecret, created: false };
+        return {
+          id: existing.id,
+          signingSecret: existing.signingSecret,
+          created: false,
+        };
       }
 
       const signingSecret = generateSigningSecret();
@@ -136,41 +155,53 @@ export async function POST(request: Request): Promise<NextResponse> {
     const isUniqueViolation = isDbError(error) && error.code === "23505";
 
     if (isUniqueViolation) {
-      const [existing] = await db
-        .select({
-          id: webhookConfigs.id,
-          apiKey: webhookConfigs.apiKey,
-          signingSecret: webhookConfigs.signingSecret,
-        })
-        .from(webhookConfigs)
-        .where(
-          and(
-            eq(webhookConfigs.serverUrl, serverUrl),
-            eq(webhookConfigs.webhook, webhookUrl)
+      try {
+        const [existing] = await db
+          .select({
+            id: webhookConfigs.id,
+            apiKey: webhookConfigs.apiKey,
+            signingSecret: webhookConfigs.signingSecret,
+          })
+          .from(webhookConfigs)
+          .where(
+            and(
+              eq(webhookConfigs.serverUrl, serverUrl),
+              eq(webhookConfigs.webhook, webhookUrl)
+            )
           )
-        )
-        .limit(1);
+          .limit(1);
 
-      if (existing) {
-        if (existing.apiKey !== apiKey) {
-          const signingSecret = generateSigningSecret();
-          await db
-            .update(webhookConfigs)
-            .set({ apiKey, signingSecret, updatedAt: new Date() })
-            .where(eq(webhookConfigs.id, existing.id));
-          return NextResponse.json({ id: existing.id, signingSecret });
+        if (existing) {
+          if (existing.apiKey !== apiKey) {
+            const signingSecret = generateSigningSecret();
+            await db
+              .update(webhookConfigs)
+              .set({ apiKey, signingSecret, updatedAt: new Date() })
+              .where(eq(webhookConfigs.id, existing.id));
+            return NextResponse.json({ id: existing.id, signingSecret });
+          }
+          return NextResponse.json({
+            id: existing.id,
+            signingSecret: existing.signingSecret,
+          });
         }
-        return NextResponse.json({
-          id: existing.id,
-          signingSecret: existing.signingSecret,
-        });
+      } catch (recoveryError) {
+        console.error(
+          "Failed to recover from unique violation:",
+          recoveryError
+        );
       }
+
+      return createErrorResponse(
+        "CONFLICT_RETRY",
+        "A concurrent request created this webhook. Retry to retrieve the existing record."
+      );
     }
 
     console.error("Failed to upsert webhook config:", error);
-    return NextResponse.json(
-      { error: "Internal server error." },
-      { status: 500 }
+    return createErrorResponse(
+      "DATABASE_ERROR",
+      "Failed to upsert webhook config."
     );
   }
 
@@ -187,18 +218,15 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     request.nextUrl.searchParams.get("apiKey");
 
   if (!serverUrl || !apiKey) {
-    return NextResponse.json(
-      { error: "serverUrl and apiKey (header x-api-key or query param) are required." },
-      { status: 400 }
+    return createErrorResponse(
+      "MISSING_QUERY_PARAMS",
+      "serverUrl and apiKey (header x-api-key or query param) are required."
     );
   }
 
-  if (!(await verifyServerCredentials(serverUrl, apiKey))) {
-    return NextResponse.json(
-      { error: "Invalid server URL or API key." },
-      { status: 401 }
-    );
-  }
+  const verifyResult = await verifyServerCredentials(serverUrl, apiKey);
+  const verifyError = verifyOrError(verifyResult);
+  if (verifyError) return verifyError;
 
   try {
     const rows = await db
@@ -214,9 +242,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json(rows);
   } catch (error) {
     console.error("Failed to fetch webhook configs:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch webhook configs." },
-      { status: 500 }
+    return createErrorResponse(
+      "DATABASE_ERROR",
+      "Failed to fetch webhook configs."
     );
   }
 }
@@ -228,18 +256,15 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
     request.nextUrl.searchParams.get("apiKey");
 
   if (!serverUrl || !apiKey) {
-    return NextResponse.json(
-      { error: "serverUrl and apiKey (header x-api-key or query param) are required." },
-      { status: 400 }
+    return createErrorResponse(
+      "MISSING_QUERY_PARAMS",
+      "serverUrl and apiKey (header x-api-key or query param) are required."
     );
   }
 
-  if (!(await verifyServerCredentials(serverUrl, apiKey))) {
-    return NextResponse.json(
-      { error: "Invalid server URL or API key." },
-      { status: 401 }
-    );
-  }
+  const verifyResult = await verifyServerCredentials(serverUrl, apiKey);
+  const verifyError = verifyOrError(verifyResult);
+  if (verifyError) return verifyError;
 
   try {
     const deleted = await db
@@ -250,9 +275,9 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ deleted: deleted.length });
   } catch (error) {
     console.error("Failed to delete webhook configs:", error);
-    return NextResponse.json(
-      { error: "Failed to delete webhook configs." },
-      { status: 500 }
+    return createErrorResponse(
+      "DATABASE_ERROR",
+      "Failed to delete webhook configs."
     );
   }
 }

--- a/apps/web/src/app/api/webhooks/route.ts
+++ b/apps/web/src/app/api/webhooks/route.ts
@@ -23,7 +23,7 @@ function isDbError(err: unknown): err is Error & { code: string } {
   );
 }
 
-async function verifyServerCredentials(
+function verifyServerCredentials(
   serverUrl: string,
   apiKey: string
 ): Promise<VerifyResult> {
@@ -36,7 +36,9 @@ async function verifyServerCredentials(
 
     let finished = false;
     const cleanup = (result: VerifyResult) => {
-      if (finished) return;
+      if (finished) {
+        return;
+      }
       finished = true;
       clearTimeout(timer);
       try {
@@ -57,7 +59,9 @@ async function verifyServerCredentials(
 }
 
 function verifyOrError(result: VerifyResult): NextResponse | null {
-  if (result === "ok") return null;
+  if (result === "ok") {
+    return null;
+  }
   if (result === "timeout") {
     return createErrorResponse(
       "CREDENTIAL_VERIFICATION_TIMEOUT",
@@ -106,7 +110,9 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   const verifyResult = await verifyServerCredentials(serverUrl, apiKey);
   const verifyError = verifyOrError(verifyResult);
-  if (verifyError) return verifyError;
+  if (verifyError) {
+    return verifyError;
+  }
 
   let result: { id: string; signingSecret: string; created: boolean };
 
@@ -217,7 +223,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     request.headers.get("x-api-key") ??
     request.nextUrl.searchParams.get("apiKey");
 
-  if (!serverUrl || !apiKey) {
+  if (!(serverUrl && apiKey)) {
     return createErrorResponse(
       "MISSING_QUERY_PARAMS",
       "serverUrl and apiKey (header x-api-key or query param) are required."
@@ -226,7 +232,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   const verifyResult = await verifyServerCredentials(serverUrl, apiKey);
   const verifyError = verifyOrError(verifyResult);
-  if (verifyError) return verifyError;
+  if (verifyError) {
+    return verifyError;
+  }
 
   try {
     const rows = await db
@@ -255,7 +263,7 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
     request.headers.get("x-api-key") ??
     request.nextUrl.searchParams.get("apiKey");
 
-  if (!serverUrl || !apiKey) {
+  if (!(serverUrl && apiKey)) {
     return createErrorResponse(
       "MISSING_QUERY_PARAMS",
       "serverUrl and apiKey (header x-api-key or query param) are required."
@@ -264,7 +272,9 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
 
   const verifyResult = await verifyServerCredentials(serverUrl, apiKey);
   const verifyError = verifyOrError(verifyResult);
-  if (verifyError) return verifyError;
+  if (verifyError) {
+    return verifyError;
+  }
 
   try {
     const deleted = await db


### PR DESCRIPTION
## Summary

- Add a shared error response module (`errors.ts`) with typed error codes, categories, retry signals, and a `createErrorResponse` helper
- Migrate all 15 error paths across `/api/webhooks` and `/api/webhooks/[id]` to return structured, machine-readable error responses
- Fix missing `try/catch` in `[id]/route.ts` that could leak stack traces on DB failures
- Differentiate credential verification timeout from invalid credentials (agents can now retry timeouts)

All changes are **additive** — the existing `error` string field is preserved. New fields (`code`, `status`, `category`, `retryable`, `retry_after`, `suggested_action`, `request_id`, `timestamp`) are added alongside it. Success responses are unchanged.

## Before / after

**Before:**
```json
{
  "error": "Invalid server URL or API key."
}
```

**After:**
```json
{
  "error": "Invalid server URL or API key.",
  "code": "INVALID_CREDENTIALS",
  "status": 401,
  "category": "authentication",
  "retryable": false,
  "suggested_action": "Verify that serverUrl is reachable and apiKey is correct.",
  "request_id": "req_a1b2c3d4e5f6a7b8",
  "timestamp": "2026-04-03T12:00:00.000Z"
}
```

## Commits

1. **`feat: add structured error response module`** — `errors.ts` with types, error code registry, and `createErrorResponse` helper
2. **`feat: migrate collection route errors to structured responses`** — POST/GET/DELETE `/api/webhooks` migrated; `verifyServerCredentials` now returns `"ok" | "invalid" | "timeout"` to differentiate auth failures; unique-violation recovery wrapped in try/catch
3. **`fix: add missing try/catch and structured errors to [id] route`** — DB delete wrapped in try/catch; all error paths use structured responses

## Test plan

- [x] POST `/api/webhooks` with invalid JSON → verify `INVALID_JSON_BODY` error shape
- [x] POST with missing fields → verify `MISSING_REQUIRED_FIELDS`
- [x] POST with malformed URLs → verify `INVALID_URL_FORMAT`
- [x] POST with wrong API key → verify `INVALID_CREDENTIALS` with `retryable: false`
- [x] POST with unreachable server (timeout) → verify `CREDENTIAL_VERIFICATION_TIMEOUT` with `retryable: true, retry_after: 5`
- [x] POST with valid credentials → verify success response unchanged (201/200)
- [x] GET without params → verify `MISSING_QUERY_PARAMS`
- [x] GET with invalid credentials → verify `INVALID_CREDENTIALS`
- [x] GET with valid credentials → verify success response unchanged (array)
- [x] DELETE without params → verify `MISSING_QUERY_PARAMS`
- [x] DELETE `/api/webhooks/[id]` with nonexistent ID → verify `WEBHOOK_NOT_FOUND`
- [x] DELETE `/api/webhooks/[id]` with valid ID → verify 204 unchanged
- [x] All error responses include `request_id`, `timestamp`, `code`, `status`, `category`, `retryable`, `suggested_action`
- [x] All error responses preserve the `error` string field for backward compatibility
- [x] Biome check passes with no new errors

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses for webhook operations, including better handling of missing webhooks, database failures, and credential verification timeouts.
  * Enhanced duplicate webhook detection with improved recovery handling.
  * Standardized error tracking with request IDs for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->